### PR TITLE
Updated Processor.Process to use io.Writer

### DIFF
--- a/cmd/caire/main.go
+++ b/cmd/caire/main.go
@@ -102,24 +102,30 @@ func main() {
 		}
 
 		for in, out := range toProcess {
-			file, err := os.Open(in)
+			inFile, err := os.Open(in)
 			if err != nil {
 				log.Fatalf("Unable to open source file: %v", err)
 			}
-			defer file.Close()
+			defer inFile.Close()
+
+			outFile, err := os.Open(out)
+			if err != nil {
+				log.Fatalf("Unable to open source file: %v", err)
+			}
+			defer outFile.Close()
 
 			s := new(spinner)
 			s.start("Processing...")
 
 			start := time.Now()
-			_, err = p.Process(file, out)
+			err = p.Process(inFile, outFile)
 			s.stop()
 
 			if err == nil {
 				fmt.Printf("\nRescaled in: \x1b[92m%.2fs\n", time.Since(start).Seconds())
 				fmt.Printf("\x1b[39mSaved as: \x1b[92m%s \n\n", path.Base(out))
 			} else {
-				fmt.Printf("\nError rescaling image: %s. Reason: %s\n", file.Name(), err.Error())
+				fmt.Printf("\nError rescaling image: %s. Reason: %s\n", inFile.Name(), err.Error())
 			}
 		}
 	} else {

--- a/cmd/caire/main.go
+++ b/cmd/caire/main.go
@@ -108,9 +108,9 @@ func main() {
 			}
 			defer inFile.Close()
 
-			outFile, err := os.Open(out)
+			outFile, err := os.OpenFile(out, os.O_CREATE|os.O_WRONLY, 0755)
 			if err != nil {
-				log.Fatalf("Unable to open source file: %v", err)
+				log.Fatalf("Unable to open output file: %v", err)
 			}
 			defer outFile.Close()
 

--- a/process.go
+++ b/process.go
@@ -8,7 +8,6 @@ import (
 	_ "image/jpeg"
 	_ "image/png"
 	"io"
-	"os"
 
 	"github.com/pkg/errors"
 	_ "golang.org/x/image/bmp"
@@ -122,27 +121,22 @@ func (p *Processor) Resize(img *image.NRGBA) (image.Image, error) {
 }
 
 // Process image.
-func (p *Processor) Process(file io.Reader, output string) (*os.File, error) {
-	src, _, err := image.Decode(file)
+func (p *Processor) Process(r io.Reader, w io.Writer) error {
+	src, _, err := image.Decode(r)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	img := imgToNRGBA(src)
 	res, err := Resize(p, img)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	fq, err := os.Create(output)
-	if err != nil {
-		return nil, err
+	if err = jpeg.Encode(w, res, &jpeg.Options{100}); err != nil {
+		return err
 	}
-	defer fq.Close()
 
-	if err = jpeg.Encode(fq, res, &jpeg.Options{100}); err != nil {
-		return nil, err
-	}
-	return fq, nil
+	return nil
 }
 
 // Converts any image type to *image.NRGBA with min-point at (0, 0).


### PR DESCRIPTION
Updated `Processor.Process` to use `io.Writer` for output instead of a filename so in-memory operations can be performed easily.