### PR TITLE
Add support for building snaps

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,21 @@
+name: caire
+version: '1.0'
+summary: Content aware image resize library 
+description: |
+  Content aware image resize library
+grade: stable
+confinement: strict
+base: core18
+parts:
+  caire:
+    plugin: go
+    source: https://github.com/esimov/caire.git
+    go-importpath: github.com/esimov/caire
+    build-packages:
+      - build-essential
+apps:
+  caire:
+    command: bin/caire
+    plugs:
+      - home
+      - x11


### PR DESCRIPTION
Hello Endre,

Can you also make caire available as a snap?

I think this would be a nice thing, and you might reach a very large audience of Linux users, as snaps in the Snap Store are available to millions. You also get seamless cross-distro support (any snap-capable distro will be able to install it and use without any modifications), plus automatic updates, so you if you change your FR algorithms, everyone gets them.

Purely on the image processing side, I installed caire as a snap and tested it, and it works well.

I built it with access to home and X11, but it is also possible to give it network access (if it needs to download FR data).

Here's the set of steps you need to run to get this done:

1) snap install snapcraft --classic --beta
2) git clone https://github.com/igorljubuncic/caire.git
3) cd caire
4) git checkout add-snapcraft
5) snapcraft
6) snap install caire_1.0_amd64.snap --dangerous
7) snap run caire "options"
8) Register a developer account in the snap store https://snapcraft.io/account
9) snapcraft login
10) snapcraft register
11) snapcraft push caire_1.0_amd64.snap --release edge
12) snap install caire --edge

**Details**

1-5) Install snapcraft command line tool to build snaps and build from snapcraft.yaml (from this PR).
6) Local test install. The --dangerous flag because the snap isn't signed (it will be once pushed to the store).
9-10) Command line login and caire name registration.
11) Upload a built snap to the store. The store supports multiple risk levels as “channels” - edge, beta, candidate, stable. 
12) Test install from the store.

**Other information**

You can also use a CI system or our free build system (build.snapcraft.io).

Let me know if this works for you, or if you have any questions.

Take care.