### PR TITLE
Clear ANSI Colors after final print

### DIFF
--- a/cmd/caire/main.go
+++ b/cmd/caire/main.go
@@ -146,8 +146,8 @@ func main() {
 			s.stop()
 
 			if err == nil {
-				fmt.Printf("\nRescaled in: \x1b[92m%.2fs\n", time.Since(start).Seconds())
-				fmt.Printf("\x1b[39mSaved as: \x1b[92m%s \n\n", path.Base(out))
+				fmt.Printf("\nRescaled in: \x1b[92m%.2fs\n\x1b[0m", time.Since(start).Seconds())
+				fmt.Printf("\x1b[39mSaved as: \x1b[92m%s \n\n\x1b[0m", path.Base(out))
 			} else {
 				fmt.Printf("\nError rescaling image %s. Reason: %s\n", inFile.Name(), err.Error())
 			}


### PR DESCRIPTION
Green ANSI color `\x1b[92` is left set as part of the final print, as described in #42, #27, and #23. This commit resets ANSI color to `\x1b[0m` (no attributes) after final status message.