### PR TITLE
Improved scaling

### DIFF
--- a/process.go
+++ b/process.go
@@ -181,16 +181,12 @@ func (p *Processor) Resize(img *image.NRGBA) (image.Image, error) {
 			hScaleFactor := float64(c.Height) / float64(p.NewHeight)
 			scaleWidth := math.Round(float64(c.Width) / math.Min(wScaleFactor, hScaleFactor)) //post scale width
 			scaleHeight := math.Round(float64(c.Height) / math.Min(wScaleFactor, hScaleFactor)) // post scale height
+			
 			newImg = resize.Resize(uint(scaleWidth), uint(scaleHeight), img, resize.Lanczos3)
-			
-			if wScaleFactor > hScaleFactor {	
-				newWidth = int(scaleWidth) - p.NewWidth
-				newHeight = 0
-			} else {
-				newWidth = 0
-				newHeight = int(scaleHeight) - p.NewHeight
-			}
-			
+			// The amount needed to remove by carving. One or both of these will be 0.
+			newWidth = int(scaleWidth) - p.NewWidth
+			newHeight = int(scaleHeight) - p.NewHeight
+
 			dst := image.NewNRGBA(newImg.Bounds())
 			draw.Draw(dst, newImg.Bounds(), newImg, image.ZP, draw.Src)
 			img = dst


### PR DESCRIPTION
This change targets the scaling done before seam carving the image. The new scaling works by:
1. Finding the scale factor (input length / target length) for each side.
2. Dividing the input side lengths by the smaller of these two factors to get the side lengths after scaling.
3. Calculating the remaining pixels needed to be removed by carving by subtracting the target length from scale length.

What this will do is scale one side directly to the target length, and the other proportionally larger than the target length. As an example, if an input of 5000x2500 has a target resize of 1920x1080, it is first scaled to 2160x1080. The amount of pixels needed to be removed by carving is then 240x0.